### PR TITLE
add default values to fix south migration

### DIFF
--- a/sanitizer/models.py
+++ b/sanitizer/models.py
@@ -7,7 +7,7 @@ import bleach
 
 class SanitizedCharField(models.CharField):
     
-    def __init__(self, allowed_tags, allowed_attributes, strip=False, *args, **kwargs):
+    def __init__(self, allowed_tags=None, allowed_attributes=None, strip=False, *args, **kwargs):
         self._sanitizer_allowed_tags = allowed_tags
         self._sanitizer_allowed_attributes = allowed_attributes
         self._sanitizer_strip = strip
@@ -22,7 +22,7 @@ class SanitizedCharField(models.CharField):
 
 class SanitizedTextField(models.TextField):
     
-    def __init__(self, allowed_tags, allowed_attributes, strip=False, *args, **kwargs):
+    def __init__(self, allowed_tags=None, allowed_attributes=None, strip=False, *args, **kwargs):
         self._sanitizer_allowed_tags = allowed_tags
         self._sanitizer_allowed_attributes = allowed_attributes
         self._sanitizer_strip = strip


### PR DESCRIPTION
South generate error on schemamigration, add_introspection_rules is wrong, you don't define default values for required arguments. Anyway in this case I think the best thing to do is to add default values to constructor.

South error : TypeError: **init**() takes at least 3 arguments (1 given)
