### PR TITLE
Issue migrating when using model fields

### DIFF
--- a/sanitizer/models.py
+++ b/sanitizer/models.py
@@ -45,5 +45,17 @@ class SanitizedTextField(models.TextField):
 
 if 'south' in settings.INSTALLED_APPS:
     from south.modelsinspector import add_introspection_rules
-    add_introspection_rules([], ["^sanitizer\.models\.SanitizedCharField"])
-    add_introspection_rules([], ["^sanitizer\.models\.SanitizedTextField"])
+    rules = [
+      (
+        (SanitizedCharField, SanitizedTextField),
+        [],
+        {
+            "allowed_tags": ["_sanitizer_allowed_tags", {}],
+            "allowed_attributes": ["_sanitizer_allowed_attributes", {}],
+            "strip": ["_sanitizer_strip", {}],
+        },
+      )
+    ]
+
+    add_introspection_rules(rules, ["^sanitizer\.models\.SanitizedCharField"])
+    add_introspection_rules(rules, ["^sanitizer\.models\.SanitizedTextField"])


### PR DESCRIPTION
Scenario:
1. create a model with SanitizedCharField or SanitizedTextField with keyword arguments (e.g. SanitizedCharField(allowed_tags=["p", "ul", "li"]))
2. create a ./manage.py schemamigration --auto
3. ./manage.py migrate

Currently, step 3 fails because SanitizedCharField and SanitizedTextField receives keyword arguments that south knows nothing about. The pull request fixes this by adding some introspection rules.
