### PR TITLE
Add missing files to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
 include LICENSE.txt
 include README.rst
+include MANIFEST.in
+include sanitizer/templatetags/*


### PR DESCRIPTION
The first part of the problem I had in testing with the new bleach/html5lib is that the sdist (which I was using) is incomplete.  This MANIFEST.in update will fix that.  This is a pre-requisite to addressing https://github.com/ui/django-html_sanitizer/issues/13