### PR TITLE
Django 4.0 compatibility: smart_str

### DIFF
--- a/sanitizer/__init__.py
+++ b/sanitizer/__init__.py
@@ -1,3 +1,3 @@
-VERSION = (0, 1, 4)
+VERSION = (0, 1, 6)
 
 from .decorators import sanitize

--- a/sanitizer/decorators.py
+++ b/sanitizer/decorators.py
@@ -16,12 +16,11 @@ class sanitize(object):
 
     
     def __init__(self, tags=bleach.ALLOWED_TAGS,
-                 attributes=bleach.ALLOWED_ATTRIBUTES, styles=[], strip=False,
+                 attributes=bleach.ALLOWED_ATTRIBUTES, strip=False,
                  strip_comments=True):
         self.kwargs = {
             'tags': tags,
             'attributes': attributes,
-            'styles': styles,
             'strip': strip,
             'strip_comments': strip_comments,
         }

--- a/sanitizer/forms.py
+++ b/sanitizer/forms.py
@@ -8,10 +8,9 @@ class SanitizedCharField(forms.CharField):
     A subclass of CharField that escapes (or strip) HTML tags and attributes.
     """    
     def __init__(self, allowed_tags=[], allowed_attributes=[], 
-            allowed_styles=[], strip=False, *args, **kwargs):
+            strip=False, *args, **kwargs):
         self._allowed_tags = allowed_tags
         self._allowed_attributes = allowed_attributes
-        self._allowed_styles = allowed_styles
         self._strip = strip
         super(SanitizedCharField, self).__init__(*args, **kwargs)
 
@@ -19,4 +18,4 @@ class SanitizedCharField(forms.CharField):
         value = super(SanitizedCharField, self).clean(value)
         return bleach.clean(value, tags=self._allowed_tags,
             attributes=self._allowed_attributes, 
-            styles=self._allowed_styles, strip=self._strip)
+            strip=self._strip)

--- a/sanitizer/models.py
+++ b/sanitizer/models.py
@@ -3,7 +3,10 @@ from django.db import models
 
 import sys
 if sys.version_info[0] == 3:
-    from django.utils.encoding import smart_text as smart_unicode
+    try:
+        from django.utils.encoding import smart_str as smart_unicode
+    except ImportError:
+        from django.utils.encoding import smart_text as smart_unicode
 else:
     from django.utils.encoding import smart_unicode
 

--- a/sanitizer/models.py
+++ b/sanitizer/models.py
@@ -16,11 +16,10 @@ import bleach
 class SanitizedCharField(models.CharField):
     
     def __init__(self, allowed_tags=[], allowed_attributes=[],
-                 allowed_styles=[], strip=False, 
+                 strip=False, 
                  *args, **kwargs):
         self._sanitizer_allowed_tags = allowed_tags
         self._sanitizer_allowed_attributes = allowed_attributes
-        self._sanitizer_allowed_styles = allowed_styles
         self._sanitizer_strip = strip
         super(SanitizedCharField, self).__init__(*args, **kwargs)
 
@@ -28,18 +27,17 @@ class SanitizedCharField(models.CharField):
         value = super(SanitizedCharField, self).to_python(value)
         value = bleach.clean(value, tags=self._sanitizer_allowed_tags,
             attributes=self._sanitizer_allowed_attributes, 
-            styles=self._sanitizer_allowed_styles, strip=self._sanitizer_strip)
+            strip=self._sanitizer_strip)
         return smart_unicode(value)
 
 
 class SanitizedTextField(models.TextField):
     
     def __init__(self, allowed_tags=[], allowed_attributes=[], 
-                 allowed_styles=[], strip=False, 
+                 strip=False, 
                  *args, **kwargs):
         self._sanitizer_allowed_tags = allowed_tags
         self._sanitizer_allowed_attributes = allowed_attributes
-        self._sanitizer_allowed_styles = allowed_styles
         self._sanitizer_strip = strip
         super(SanitizedTextField, self).__init__(*args, **kwargs)
 
@@ -47,14 +45,14 @@ class SanitizedTextField(models.TextField):
         value = super(SanitizedTextField, self).to_python(value)
         value = bleach.clean(value, tags=self._sanitizer_allowed_tags,
             attributes=self._sanitizer_allowed_attributes, 
-            styles=self._sanitizer_allowed_styles, strip=self._sanitizer_strip)
+            strip=self._sanitizer_strip)
         return smart_unicode(value)
 
     def get_prep_value(self, value):
         value = super(SanitizedTextField, self).get_prep_value(value)
         value = bleach.clean(value, tags=self._sanitizer_allowed_tags,
             attributes=self._sanitizer_allowed_attributes, 
-            styles=self._sanitizer_allowed_styles, strip=self._sanitizer_strip)
+            strip=self._sanitizer_strip)
         return value
 
 

--- a/sanitizer/templatetags/sanitizer.py
+++ b/sanitizer/templatetags/sanitizer.py
@@ -11,7 +11,6 @@ if sys.version_info[0] == 3:
 
 ALLOWED_TAGS = getattr(settings, 'SANITIZER_ALLOWED_TAGS', [])
 ALLOWED_ATTRIBUTES = getattr(settings, 'SANITIZER_ALLOWED_ATTRIBUTES', [])
-ALLOWED_STYLES = getattr(settings, 'SANITIZER_ALLOWED_STYLES', [])
 
 register = template.Library()
 
@@ -19,8 +18,8 @@ register = template.Library()
 @stringfilter
 def sanitize(value):
     '''
-    Sanitizes strings according to SANITIZER_ALLOWED_TAGS,
-    SANITIZER_ALLOWED_ATTRIBUTES and SANITIZER_ALLOWED_STYLES variables in
+    Sanitizes strings according to SANITIZER_ALLOWED_TAGS and
+    SANITIZER_ALLOWED_ATTRIBUTES variables in
     settings.
 
     Example usage:
@@ -32,7 +31,7 @@ def sanitize(value):
     if isinstance(value, basestring):
         value = bleach.clean(value, tags=ALLOWED_TAGS,
                              attributes=ALLOWED_ATTRIBUTES, 
-                             styles=ALLOWED_STYLES, strip=False)
+                             strip=False)
     return value
 
 register.filter('escape_html', sanitize)
@@ -41,8 +40,8 @@ register.filter('escape_html', sanitize)
 @stringfilter
 def strip_filter(value):
     '''
-    Strips HTML tags from strings according to SANITIZER_ALLOWED_TAGS,
-    SANITIZER_ALLOWED_ATTRIBUTES and SANITIZER_ALLOWED_STYLES variables in
+    Strips HTML tags from strings according to SANITIZER_ALLOWED_TAGS
+    and SANITIZER_ALLOWED_ATTRIBUTES variables in
     settings.
 
     Example usage:
@@ -54,7 +53,7 @@ def strip_filter(value):
     if isinstance(value, basestring):
         value = bleach.clean(value, tags=ALLOWED_TAGS,
                              attributes=ALLOWED_ATTRIBUTES, 
-                             styles=ALLOWED_STYLES, strip=True)
+                             strip=True)
     return value
 
 register.filter('strip_html', strip_filter)
@@ -72,7 +71,6 @@ def sanitize_allow(value, args=''):
     if isinstance(value, basestring):
         allowed_tags = []
         allowed_attributes = []
-        allowed_styles = []
         
         args = args.strip().split(';')
         if len(args) > 0:
@@ -88,11 +86,10 @@ register.filter('sanitize_allow', sanitize_allow)
 
 
 @register.simple_tag
-def escape_html(value, allowed_tags=[], allowed_attributes=[],
-                allowed_styles=[]):
+def escape_html(value, allowed_tags=[], allowed_attributes=[]):
     """
     Template tag to sanitize string values. It accepts lists of
-    allowed tags, attributes or styles in comma separated string or list format.
+    allowed tags or attributes in comma separated string or list format.
 
     For example:
 
@@ -111,16 +108,15 @@ def escape_html(value, allowed_tags=[], allowed_attributes=[],
     if isinstance(value, basestring):
         value = bleach.clean(value, tags=allowed_tags,
                              attributes=allowed_attributes, 
-                             styles=allowed_styles, strip=False)
+                             strip=False)
     return value
 
 
 @register.simple_tag
-def strip_html(value, allowed_tags=[], allowed_attributes=[],
-               allowed_styles=[]):
+def strip_html(value, allowed_tags=[], allowed_attributes=[]):
     """
     Template tag to strip html from string values. It accepts lists of
-    allowed tags, attributes or stylesin comma separated string or list format.
+    allowed tags or attributes in comma separated string or list format.
 
     For example:
 
@@ -139,5 +135,5 @@ def strip_html(value, allowed_tags=[], allowed_attributes=[],
     if isinstance(value, basestring):
         value = bleach.clean(value, tags=allowed_tags,
                              attributes=allowed_attributes, 
-                             styles=allowed_styles, strip=True)
+                             strip=True)
     return value

--- a/sanitizer/tests.py
+++ b/sanitizer/tests.py
@@ -11,22 +11,21 @@ from .models import SanitizedCharField, SanitizedTextField
 
 ALLOWED_TAGS = ['a']
 ALLOWED_ATTRIBUTES = ['href', 'style']
-ALLOWED_STYLES = ['width']
 
 
 class TestingModel(models.Model):
     test_field = SanitizedCharField(max_length=255, allowed_tags=ALLOWED_TAGS, 
-        allowed_attributes=ALLOWED_ATTRIBUTES, allowed_styles=ALLOWED_STYLES)
+        allowed_attributes=ALLOWED_ATTRIBUTES)
 
 
 class TestingTextModel(models.Model):
     test_field = SanitizedTextField(allowed_tags=ALLOWED_TAGS, 
-        allowed_attributes=ALLOWED_ATTRIBUTES, allowed_styles=ALLOWED_STYLES)
+        allowed_attributes=ALLOWED_ATTRIBUTES)
 
 
 class TestForm(forms.Form):
     test_field = SanitizedFormField(allowed_tags=['a'], 
-    allowed_attributes=['href', 'style'], allowed_styles=['width'])
+    allowed_attributes=['href', 'style'])
 
 
 class SanitizerTest(TestCase):
@@ -70,17 +69,17 @@ class SanitizerTest(TestCase):
     def test_escape_html(self):
         html = '<a href="" class="" style="width: 200px; height: 400px">foo</a><em></em>'
         self.assertEqual(escape_html(html, allowed_tags='a', 
-            allowed_attributes='href,style', allowed_styles='width'),
+            allowed_attributes='href,style'),
             '<a href="" style="width: 200px;">foo</a>&lt;em&gt;&lt;/em&gt;')
         self.assertEqual(escape_html(html, allowed_tags=['a'], 
-            allowed_attributes=['href', 'style'], allowed_styles=['width']),
+            allowed_attributes=['href', 'style']),
             '<a href="" style="width: 200px;">foo</a>&lt;em&gt;&lt;/em&gt;')
     
     def test_strip_html(self):
         html = '<a href="" class="" style="width: 200px; height: 400px">foo</a><em></em>'
         self.assertEqual(strip_html(html, allowed_tags='a', 
-            allowed_attributes='href,style', allowed_styles='width'),
+            allowed_attributes='href,style'),
             '<a href="" style="width: 200px;">foo</a>')
         self.assertEqual(strip_html(html, allowed_tags=['a'], 
-            allowed_attributes=['href', 'style'], allowed_styles=['width']),
+            allowed_attributes=['href', 'style']),
             '<a href="" style="width: 200px;">foo</a>')

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     long_description=open('README.rst').read(),
     zip_safe=False,
     include_package_data=True,
-    install_requires=['django', 'bleach~=6'],
+    install_requires=['django', 'bleach>=6'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     long_description=open('README.rst').read(),
     zip_safe=False,
     include_package_data=True,
-    install_requires=['django', 'bleach'],
+    install_requires=['django', 'bleach~=6'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='django-html_sanitizer',
-    version='0.1.5',
+    version='0.1.6',
     author='Selwin Ong',
     author_email='selwin.ong@gmail.com',
     packages=['sanitizer'],

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='django-html_sanitizer',
-    version='0.1.6',
+    version='0.1.7',
     author='Selwin Ong',
     author_email='selwin.ong@gmail.com',
     packages=['sanitizer'],


### PR DESCRIPTION
In django 4.0, django.utils.encoding.smart_text is removed; it's now known as smart_str.

It was deprecated in django 3.0: https://docs.djangoproject.com/en/4.1/releases/3.0/#django-utils-encoding-force-text-and-smart-text